### PR TITLE
Using MODULES for building .so instead of MODULE_big.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 EXTENSION = zson
 MODULES = zson
 DATA = zson--1.1.sql zson--1.0--1.1.sql
-OBJS = zson.o
 REGRESS = zson
 
-MODULE_big = zson
 PG_CPPFLAGS = -g -O2
 SHLIB_LINK = # -lz -llz4
 
-PGXS := $(shell pg_config --pgxs)
+ifndef PG_CONFIG
+	PG_CONFIG := pg_config
+endif
+PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
This is fix of my previous commit 1443ae084d54.

PGXS supports two ways of building shared libraries: building an so for each
module specified in MODULES and building one big so named MODULE_big for all
modules specified in OBJS. Previously this extension used the latter, but also
specified MODULES variable for no reason, which is pretty strange. Since
extension contains just one module, it is sane to use the former. I have removed
OBJS variable, but forgot to remove MODULE_big in my previous commit, which
broke the build, since an empty so was assembled. This commit fixes the issue.

Besides, PG_CONFIG var is now consulted for path to pg_config, which allows to
build extension without pg_config in the PATH.